### PR TITLE
Added InheritedRocket for share data in tree widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,3 +86,4 @@
 - Removed `multi` parameter from RocketRequest method
 - Added end2end test on example
 - Renamed `multi` `RocketModel` field to `all`
+- Added `InheritedRocket` to share data between widgets in a widget tree

--- a/example/lib/views/post_view.dart
+++ b/example/lib/views/post_view.dart
@@ -67,37 +67,47 @@ class PostExample extends StatelessWidget {
                   );
                 },
                 builder: (context) {
-                  return SizedBox(
-                    height: MediaQuery.of(context).size.height * 0.852,
-                    child: ListView.builder(
-                      itemCount: post.all!.length,
-                      itemBuilder: (BuildContext context, int index) {
-                        // your data saved in multi list as Post model
-                        Post currentPost = post.all![index];
-                        return ListTile(
-                            leading: Text(currentPost.id.toString()),
-                            title: Text(currentPost.title!),
-                            trailing: IconButton(
-                              color: Colors.brown,
-                              icon: const Icon(Icons.update),
-                              onPressed: () {
-                                // update post data
-                                currentPost.updateFields(
-                                    titleField: "This Title changed");
-                              },
-                            ),
-                            onTap: () => Navigator.of(context).push(
-                                  MaterialPageRoute(
-                                      builder: (BuildContext context) {
-                                    return Details(index);
-                                  }),
-                                ));
-                      },
-                    ),
-                  );
+                  // Not Pass post model we will use it from inherited widget
+                  return const Posts();
                 },
               )),
         ));
+  }
+}
+
+class Posts extends StatelessWidget {
+  const Posts({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    // Get Post model from inherited widget
+    final post = InheritedRocket.of(context).model;
+    return SizedBox(
+      height: MediaQuery.of(context).size.height * 0.852,
+      child: ListView.builder(
+        itemCount: post.all!.length,
+        itemBuilder: (BuildContext context, int index) {
+          // your data saved in multi list as Post model
+          Post currentPost = post.all![index];
+          return ListTile(
+              leading: Text(currentPost.id.toString()),
+              title: Text(currentPost.title!),
+              trailing: IconButton(
+                color: Colors.brown,
+                icon: const Icon(Icons.update),
+                onPressed: () {
+                  // update post data
+                  currentPost.updateFields(titleField: "This Title changed");
+                },
+              ),
+              onTap: () => Navigator.of(context).push(
+                    MaterialPageRoute(builder: (BuildContext context) {
+                      return Details(index);
+                    }),
+                  ));
+        },
+      ),
+    );
   }
 }
 

--- a/lib/src/mc_rocket.dart
+++ b/lib/src/mc_rocket.dart
@@ -64,6 +64,6 @@ class InheritedRocket extends InheritedWidget {
 
   @override
   bool updateShouldNotify(InheritedRocket oldWidget) {
-    return model != oldWidget.model;
+    return true;
   }
 }

--- a/lib/src/mc_rocket.dart
+++ b/lib/src/mc_rocket.dart
@@ -53,6 +53,7 @@ class InheritedRocket extends InheritedWidget {
       : super(key: key, child: child);
 
   @override
+  // ignore: overridden_fields
   final Widget child;
 
   final RocketModel model;

--- a/lib/src/mc_rocket.dart
+++ b/lib/src/mc_rocket.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
 
-import 'package:mvc_rocket/src/mc_extensions.dart';
+import 'package:flutter/material.dart';
+import 'package:mvc_rocket/mvc_rocket.dart';
 
 /// Save your data with specific key
 /// حاص بتخزين النماذج المستحدمة و الحفاظ على البياتات
@@ -44,5 +45,24 @@ class Rocket {
   // حذف نموذج بشرط معين
   static void removeWhere(bool Function(String, dynamic) test) {
     _models.removeWhere(test);
+  }
+}
+
+class InheritedRocket extends InheritedWidget {
+  const InheritedRocket({Key? key, required this.child, required this.model})
+      : super(key: key, child: child);
+
+  @override
+  final Widget child;
+
+  final RocketModel model;
+
+  static InheritedRocket of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<InheritedRocket>()!;
+  }
+
+  @override
+  bool updateShouldNotify(InheritedRocket oldWidget) {
+    return model != oldWidget.model;
   }
 }

--- a/lib/src/mc_view.dart
+++ b/lib/src/mc_view.dart
@@ -2,11 +2,9 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:mvc_rocket/mvc_rocket.dart';
 
-import 'mc_constants.dart';
-import 'mc_exception.dart';
 import 'mc_llistenable.dart';
-import 'mc_model.dart';
 
 typedef OnError = Widget Function(RocketException error, Function() reload);
 
@@ -181,8 +179,7 @@ class ViewRocketState extends State<RocketView> {
     setState(() {});
   }
 
-  @override
-  Widget build(BuildContext context) {
+  Widget get _build {
     switch (widget.model.state) {
       case RocketState.loading:
         return Center(
@@ -199,5 +196,10 @@ class ViewRocketState extends State<RocketView> {
       case RocketState.failed:
         return widget.onError(widget.model.exception, reload);
     }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return InheritedRocket(model: widget.model, child: _build);
   }
 }


### PR DESCRIPTION
The role of `InheritedWidget` in Flutter is to provide an efficient way to share data between widgets in a widget tree. When a widget needs to access data that is higher up in the widget tree, it can use an `InheritedWidget` to access that data without having to pass it down through all the intermediate widgets.

Here are some key points about the role of `InheritedWidget` in Flutter:

1. `InheritedWidget` is a special kind of widget that can be used to share data between widgets in a widget tree.

2. `InheritedWidget` creates an `Element` that acts as a "portal" to access the data from any widget in the widget tree that needs it.

3. When the data changes, the `InheritedWidget` calls `Element.markNeedsBuild()` on the `Element` that is holding the data. This causes all widgets in the widget tree that depend on the data to be rebuilt.

4. `InheritedWidget` is very efficient because it avoids the need to pass data down through all the intermediate widgets in the widget tree. Instead, each widget can access the data directly through the `Element`.

5. `InheritedWidget` is commonly used to share app state, theme data, and localization data between widgets.

Overall, the role of `InheritedWidget` is to provide an efficient and easy-to-use way to share data between widgets in a widget tree. It is an important part of Flutter's architecture and is used widely in many apps.

source : https://poe.com/s/pI3eaEKMkGA4fkdx0B8R